### PR TITLE
fix: convert_eol 関数のコーディングスタイル修正

### DIFF
--- a/classes/functions.php
+++ b/classes/functions.php
@@ -43,7 +43,7 @@ class MWF_Functions {
 	/**
 	 * Unify line feed code to \n.
 	 *
-	 * @param sring $string String.
+	 * @param string $string String.
 	 * @return string
 	 */
 	public static function convert_eol( $string ) {

--- a/classes/functions.php
+++ b/classes/functions.php
@@ -47,7 +47,7 @@ class MWF_Functions {
 	 * @return string
 	 */
 	public static function convert_eol( $string ) {
-		return preg_replace( "/\r\n|\r|\n/", "\n", $string );
+		return is_string($string) ? preg_replace( "/\r\n|\r|\n/", "\n", $string ) : '';
 	}
 
 	/**

--- a/classes/functions.php
+++ b/classes/functions.php
@@ -43,11 +43,11 @@ class MWF_Functions {
 	/**
 	 * Unify line feed code to \n.
 	 *
-	 * @param string $string String.
+	 * @param string|null $string String.
 	 * @return string
 	 */
 	public static function convert_eol( $string ) {
-		return is_string($string) ? preg_replace( "/\r\n|\r|\n/", "\n", $string ) : '';
+		return is_string( $string ) ? preg_replace( "/\r\n|\r|\n/", "\n", $string ) : '';
 	}
 
 	/**

--- a/tests/classes/test-functions.php
+++ b/tests/classes/test-functions.php
@@ -26,6 +26,17 @@ class MWF_Functions_Test extends WP_UnitTestCase {
 
 	/**
 	 * @test
+	 * @group convert_eol
+	 */
+	public function convert_eol() {
+		$this->assertSame( "aaa\nbbb\nccc", MWF_Functions::convert_eol( "aaa\r\nbbb\rccc" ) );
+		$this->assertSame( "aaa\nbbb", MWF_Functions::convert_eol( "aaa\nbbb" ) );
+		$this->assertSame( '', MWF_Functions::convert_eol( '' ) );
+		$this->assertSame( '', MWF_Functions::convert_eol( null ) );
+	}
+
+	/**
+	 * @test
 	 * @group array_clean
 	 */
 	public function array_clean() {


### PR DESCRIPTION
## Summary
- `is_string($string)` → `is_string( $string )` に修正（WordPress コーディング規約準拠）
- `@param string` → `@param string|null` に修正（実際に null が渡されうるため）

#17 のフォローアップ。

## Test plan
- [ ] `convert_eol()` に文字列・null を渡して正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)