### PR TITLE
fix: http_build_query() の Deprecated 警告を修正 (PHP 8.1+)

### DIFF
--- a/classes/models/class.akismet.php
+++ b/classes/models/class.akismet.php
@@ -107,7 +107,7 @@ class MW_WP_Form_Akismet {
 			$akismet[ $key ] = $value;
 		}
 
-		$query_string = http_build_query( $akismet, null, '&' );
+		$query_string = http_build_query( $akismet, '', '&' );
 		if ( is_callable( array( 'Akismet', 'http_post' ) ) ) {
 			$response = Akismet::http_post( $query_string, 'comment-check' );
 		} else {

--- a/classes/services/class.redirected.php
+++ b/classes/services/class.redirected.php
@@ -171,7 +171,7 @@ class MW_WP_Form_Redirected {
 		}
 
 		if ( ! empty( $query_string ) ) {
-			return $url . '?' . http_build_query( $query_string, null, '&', PHP_QUERY_RFC3986 );
+			return $url . '?' . http_build_query( $query_string, '', '&', PHP_QUERY_RFC3986 );
 		}
 
 		return $url;


### PR DESCRIPTION
## Summary
- `http_build_query()` の第2引数 `null` を `''` に変更（PHP 8.1+ で非推奨）
- `class.redirected.php` と `class.akismet.php` の2箇所を修正

Closes #25

## Test plan
- [x] PHP 8.1+ 環境で「URL引数を有効にする」設定を有効にしてフォームページを表示し、Deprecated 警告が出ないことを確認
- [x] URL引数の引き継ぎが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)