### PR TITLE
security: ファイルアップロード処理のパス検証を強化 (5.1.2)

### DIFF
--- a/classes/controllers/class.main.php
+++ b/classes/controllers/class.main.php
@@ -332,9 +332,16 @@ class MW_WP_Form_Main_Controller {
 				continue;
 			}
 
-			$form_id  = MWF_Functions::get_form_id_from_form_key( $this->Data->get_form_key() );
-			$filepath = MW_WP_Form_Directory::generate_user_filepath( $form_id, $key, $upload_filename );
-			if ( ! file_exists( $filepath ) ) {
+			$form_id = MWF_Functions::get_form_id_from_form_key( $this->Data->get_form_key() );
+
+			try {
+				$filepath = MW_WP_Form_Directory::generate_user_filepath( $form_id, $key, $upload_filename );
+			} catch ( \Exception $e ) {
+				error_log( $e->getMessage() );
+				continue;
+			}
+
+			if ( ! $filepath || ! file_exists( $filepath ) ) {
 				continue;
 			}
 

--- a/classes/models/class.data.php
+++ b/classes/models/class.data.php
@@ -607,8 +607,17 @@ class MW_WP_Form_Data {
 		foreach ( $upload_file_keys as $key => $upload_file_key ) {
 			$upload_filename = $this->get_post_value_by_key( $upload_file_key );
 			$form_id         = MWF_Functions::get_form_id_from_form_key( $this->get_form_key() );
-			$filepath        = MW_WP_Form_Directory::generate_user_filepath( $form_id, $upload_file_key, $upload_filename );
-			if ( ! $upload_filename || ! file_exists( $filepath ) ) {
+
+			try {
+				$filepath = MW_WP_Form_Directory::generate_user_filepath( $form_id, $upload_file_key, $upload_filename );
+			} catch ( \Exception $e ) {
+				error_log( $e->getMessage() );
+				unset( $upload_file_keys[ $key ] );
+				$this->set( $upload_file_key, '' );
+				continue;
+			}
+
+			if ( ! $upload_filename || ! $filepath || ! file_exists( $filepath ) ) {
 				unset( $upload_file_keys[ $key ] );
 				$this->set( $upload_file_key, '' );
 			}

--- a/classes/models/class.directory.php
+++ b/classes/models/class.directory.php
@@ -39,6 +39,10 @@ class MW_WP_Form_Directory {
 			throw new \RuntimeException( '[MW WP Form] Failed to create user directory.' );
 		}
 
+		if ( ! preg_match( '/^\d+$/', (string) $form_id ) ) {
+			throw new \RuntimeException( '[MW WP Form] Invalid form ID.' );
+		}
+
 		$user_dir = path_join( static::get(), $saved_token );
 		$user_dir = path_join( $user_dir, (string) $form_id );
 
@@ -54,8 +58,16 @@ class MW_WP_Form_Directory {
 	 * @throws \RuntimeException When directory name is not token value.
 	 */
 	public static function generate_user_file_dirpath( $form_id, $name ) {
+		if ( ! static::_is_valid_path_segment( $name ) ) {
+			throw new \RuntimeException( '[MW WP Form] Invalid file reference requested.' );
+		}
+
 		$user_dir      = static::generate_user_dirpath( $form_id );
 		$user_file_dir = path_join( $user_dir, $name );
+
+		if ( ! static::_is_within_expected_dir_candidate( $form_id, $user_file_dir ) ) {
+			throw new \RuntimeException( '[MW WP Form] Invalid file reference requested.' );
+		}
 
 		return $user_file_dir;
 	}
@@ -140,20 +152,20 @@ class MW_WP_Form_Directory {
 			return false;
 		}
 
+		if ( ! static::_is_valid_path_segment( $filename ) ) {
+			throw new \RuntimeException( '[MW WP Form] Invalid file reference requested.' );
+		}
+
 		$user_file_dir = static::generate_user_file_dirpath( $form_id, $name );
 		if ( ! $user_file_dir || ! is_dir( $user_file_dir ) ) {
 			return false;
 		}
 
-		$normalized_filename = wp_normalize_path( $filename );
-		if (
-			wp_basename( $normalized_filename ) !== $normalized_filename ||
-			strstr( $normalized_filename, "\0" )
-		) {
+		$filepath = path_join( $user_file_dir, $filename );
+		if ( ! static::_is_within_expected_dir_candidate( $form_id, $filepath ) ) {
 			throw new \RuntimeException( '[MW WP Form] Invalid file reference requested.' );
 		}
 
-		$filepath      = path_join( $user_file_dir, $filename );
 		$filepath      = wp_normalize_path( $filepath );
 		$user_file_dir = trailingslashit( wp_normalize_path( $user_file_dir ) );
 
@@ -174,6 +186,92 @@ class MW_WP_Form_Directory {
 		}
 
 		return $filepath;
+	}
+
+	/**
+	 * Return true when path segment is valid.
+	 *
+	 * @param string $value Path segment.
+	 * @return boolean
+	 */
+	protected static function _is_valid_path_segment( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return false;
+		}
+
+		$value = wp_normalize_path( $value );
+
+		if ( strstr( $value, "\0" ) ) {
+			return false;
+		}
+
+		if ( '.' === $value || '..' === $value ) {
+			return false;
+		}
+
+		if ( path_is_absolute( $value ) ) {
+			return false;
+		}
+
+		if ( wp_basename( $value ) !== $value ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return true when candidate path is inside the current user's temp directory.
+	 *
+	 * @param int    $form_id Form ID.
+	 * @param string $path    Target path.
+	 * @return boolean
+	 */
+	protected static function _is_within_expected_dir_candidate( $form_id, $path ) {
+		$path = wp_normalize_path( $path );
+
+		$user_dir = static::_get_expected_user_dir( $form_id, static::get() );
+		if ( false === $user_dir ) {
+			return false;
+		}
+
+		$path           = untrailingslashit( $path );
+		$user_dir       = untrailingslashit( $user_dir );
+		$user_dir_slash = trailingslashit( $user_dir );
+
+		return $path === $user_dir || 0 === strpos( $path, $user_dir_slash );
+	}
+
+	/**
+	 * Return the expected user directory path.
+	 *
+	 * @param int         $form_id  Form ID.
+	 * @param string|bool $base_dir Base directory path.
+	 * @return string|false
+	 */
+	protected static function _get_expected_user_dir( $form_id, $base_dir ) {
+		$saved_token = MW_WP_Form_Csrf::saved_token();
+		$saved_token = $saved_token ? $saved_token : MW_WP_Form_Csrf::token();
+		if ( ! preg_match( '|^[a-z0-9]+$|', $saved_token ) ) {
+			return false;
+		}
+
+		if ( ! preg_match( '/^\d+$/', (string) $form_id ) ) {
+			return false;
+		}
+
+		if ( ! $base_dir ) {
+			return false;
+		}
+
+		$base_dir = wp_normalize_path( $base_dir );
+
+		return wp_normalize_path(
+			path_join(
+				path_join( $base_dir, $saved_token ),
+				(string) $form_id
+			)
+		);
 	}
 
 	/**

--- a/mw-wp-form.php
+++ b/mw-wp-form.php
@@ -3,7 +3,7 @@
  * Plugin Name: MW WP Form
  * Plugin URI: https://mw-wp-form.web-soudan.co.jp
  * Description: MW WP Form is shortcode base contact form plugin. This plugin have many features. For example you can use many validation rules, inquiry data saving, and chart aggregation using saved inquiry data.
- * Version: 5.1.1
+ * Version: 5.1.2
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Author: websoudan

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: plugin, form, confirm, preview, shortcode, mail, chart, graph, html, conta
 Requires at least: 6.0
 Requires PHP: 8.0
 Tested up to: 6.4
-Stable tag: 5.1.1
+Stable tag: 5.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,9 @@ Do you have questions or issues with MW WP Form? Use these support channels appr
 5. Supports chart display of saved inquiry data.
 
 == Changelog ==
+
+= 5.1.2 =
+* Security Fix insufficient file path validation in upload file handling
 
 = 5.1.1 =
 * Security Fix insufficient file path validation in upload file handling

--- a/tests/classes/models/test-data.php
+++ b/tests/classes/models/test-data.php
@@ -681,6 +681,24 @@ class MW_WP_Form_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @test
+	 * @group regenerate_upload_file_keys
+	 */
+	public function regenerate_upload_file_keys_should_drop_invalid_keys() {
+		$Data = $this->_instantiation_Data( array(
+			MWF_Config::UPLOAD_FILE_KEYS => array( '/var/www/wordpress', '../../../wordpress' ),
+		) );
+
+		$Data->set( '/var/www/wordpress', 'wp-config.php' );
+		$Data->set( '../../../wordpress', 'wp-config.php' );
+		$Data->regenerate_upload_file_keys();
+
+		$this->assertEquals( array(), $Data->get_post_value_by_key( MWF_Config::UPLOAD_FILE_KEYS ) );
+		$this->assertSame( '', $Data->get_post_value_by_key( '/var/www/wordpress' ) );
+		$this->assertSame( '', $Data->get_post_value_by_key( '../../../wordpress' ) );
+	}
+
+	/**
+	 * @test
 	 * @group push_uploaded_file_keys
 	 */
 	public function push_uploaded_file_keys() {

--- a/tests/classes/models/test-directory.php
+++ b/tests/classes/models/test-directory.php
@@ -76,4 +76,52 @@ class MW_WP_Form_Directory_Test extends WP_UnitTestCase {
 		$this->expectException( '\RuntimeException' );
 		MW_WP_Form_Directory::generate_user_filepath( $form_id, $name, 'C:\\tmp\\evil.php' );
 	}
+
+	/**
+	 * @test
+	 * @group generate_user_file_dirpath
+	 */
+	public function generate_user_file_dirpath_should_reject_absolute_path_name() {
+		MW_WP_Form_Csrf::save_token();
+		$form_id = $this->_create_form();
+
+		$this->expectException( '\RuntimeException' );
+		MW_WP_Form_Directory::generate_user_file_dirpath( $form_id, '/var/www/wordpress' );
+	}
+
+	/**
+	 * @test
+	 * @group generate_user_file_dirpath
+	 */
+	public function generate_user_file_dirpath_should_reject_nested_path_name() {
+		MW_WP_Form_Csrf::save_token();
+		$form_id = $this->_create_form();
+
+		$this->expectException( '\RuntimeException' );
+		MW_WP_Form_Directory::generate_user_file_dirpath( $form_id, 'nested/file-1' );
+	}
+
+	/**
+	 * @test
+	 * @group generate_user_file_dirpath
+	 */
+	public function generate_user_file_dirpath_should_reject_path_outside_user_dir() {
+		MW_WP_Form_Csrf::save_token();
+		$form_id = $this->_create_form();
+
+		$this->expectException( '\RuntimeException' );
+		MW_WP_Form_Directory::generate_user_file_dirpath( $form_id, '../../../wordpress' );
+	}
+
+	/**
+	 * @test
+	 * @group generate_user_file_dirpath
+	 */
+	public function generate_user_file_dirpath_should_reject_windows_absolute_path_name() {
+		MW_WP_Form_Csrf::save_token();
+		$form_id = $this->_create_form();
+
+		$this->expectException( '\RuntimeException' );
+		MW_WP_Form_Directory::generate_user_file_dirpath( $form_id, 'C:\\xampp\\htdocs\\wordpress' );
+	}
 }


### PR DESCRIPTION
## Summary
- アップロード処理におけるパス検証の不備を修正
- 入力値の検証とディレクトリ境界チェックを追加
- バージョンを 5.1.2 に更新

## Test plan
- [x] ユニットテストが通ること
- [x] ファイルアップロード付きフォームが正常に動作すること