### PR TITLE
Cookie SameSite 属性追加

### DIFF
--- a/classes/models/class.csrf.php
+++ b/classes/models/class.csrf.php
@@ -40,7 +40,14 @@ class MW_WP_Form_Csrf {
 		static::$token = ! $saved_token ? static::generate_token() : $saved_token;
 		if ( ! $saved_token && ! headers_sent() ) {
 			$secure = apply_filters( 'mwform_secure_cookie', is_ssl() );
-			setcookie( static::KEY, static::$token, 0, COOKIEPATH, COOKIE_DOMAIN, $secure, true );
+			setcookie( static::KEY, static::$token, [
+				'expires'  => 0,
+				'path'     => COOKIEPATH,
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => $secure,
+				'httponly' => true,
+				'samesite' => 'Lax',
+			] );
 		}
 	}
 


### PR DESCRIPTION
・MW_WP_Form_Session にSameSite(Lax)属性追加
・Add SameSite=Lax to cookies issued by CSRF/session handlers