### PR TITLE
fix: get_class() の引数なし呼び出しを修正 (PHP 8.3 Deprecated 対応)

### DIFF
--- a/classes/abstract/class.form-field.php
+++ b/classes/abstract/class.form-field.php
@@ -129,7 +129,7 @@ abstract class MW_WP_Form_Abstract_Form_Field {
 		$args = $this->set_names();
 
 		if ( empty( $args['shortcode_name'] ) || empty( $args['display_name'] ) ) {
-			exit( get_class() . '::set_names() returns not right values. Returned values is ' . serialize( $args ) . ' now.' );
+			exit( get_class( $this ) . '::set_names() returns not right values. Returned values is ' . serialize( $args ) . ' now.' );
 		}
 
 		$this->shortcode_name = $args['shortcode_name'];

--- a/classes/abstract/class.validation-rule.php
+++ b/classes/abstract/class.validation-rule.php
@@ -88,8 +88,8 @@ abstract class MW_WP_Form_Abstract_Validation_Rule {
 	 */
 	public function getName() {
 		MWF_Functions::deprecated_message(
-			get_class() . '::getName()',
-			get_class() . '::get_name()'
+			get_class( $this ) . '::getName()',
+			get_class( $this ) . '::get_name()'
 		);
 		return $this->get_name();
 	}


### PR DESCRIPTION
## Summary
- PHP 8.3 で非推奨となった引数なしの `get_class()` を `get_class( $this )` に修正
- Issue #34 で報告された `classes/abstract/class.validation-rule.php` の 91-92 行を修正
- 同じパターンが `classes/abstract/class.form-field.php:132` にもあったため併せて修正

Closes #34

## Test plan
- [ ] PHP 8.3+ の環境で Deprecated 警告が出ないことを確認
- [ ] バリデーションルールの `getName()` 呼び出し時に従来通りのクラス名が表示されることを確認