### PR TITLE
fix: maximagesize で未初期化の $imagesize を参照する問題を修正

### DIFF
--- a/classes/validation-rules/class.maximagesize.php
+++ b/classes/validation-rules/class.maximagesize.php
@@ -56,6 +56,7 @@ class MW_WP_Form_Validation_Rule_MaxImageSize extends MW_WP_Form_Abstract_Valida
 			$filepath = MW_WP_Form_Directory::generate_user_filepath( $form_id, $name, $value );
 		}
 
+		$imagesize = false;
 		if ( file_exists( $filepath ) && exif_imagetype( $filepath ) ) {
 			$imagesize = getimagesize( $filepath );
 		} else {
@@ -70,7 +71,7 @@ class MW_WP_Form_Validation_Rule_MaxImageSize extends MW_WP_Form_Abstract_Valida
 			'message' => __( 'This image size is too big.', 'mw-wp-form' ),
 		);
 		$options  = array_merge( $defaults, $options );
-		if ( $is_error || $imagesize[0] > $options['width'] || $imagesize[1] > $options['height'] ) {
+		if ( $is_error || ( is_array( $imagesize ) && ( $imagesize[0] > $options['width'] || $imagesize[1] > $options['height'] ) ) ) {
 			return $options['message'];
 		}
 	}


### PR DESCRIPTION
## Summary
- `classes/validation-rules/class.maximagesize.php` で、未初期化の `$imagesize` を参照することによる Undefined variable 警告を修正
- `file_exists() && exif_imagetype()` が false の場合でも、ファイルがアップロード済み (`$upload_file_keys` に含まれる) のケースでは `$is_error` も false のままとなり、未初期化の `$imagesize[0]` にアクセスしていた
- `$imagesize` を `false` で初期化し、条件式で `is_array()` チェックを追加

Closes #33

## Test plan
- [ ] 画像ファイルを maxfilesize バリデーション設定のあるフォームでアップロードし、サイズ超過時にエラーになる
- [ ] サイズ範囲内の画像でエラーにならない
- [ ] 画像でないファイル／存在しないファイルで警告が出ず、適切にエラー扱い／スルーされる