### PR TITLE
fix: setcookie 呼び出しのコーディングスタイル修正

### DIFF
--- a/classes/models/class.csrf.php
+++ b/classes/models/class.csrf.php
@@ -40,14 +40,18 @@ class MW_WP_Form_Csrf {
 		static::$token = ! $saved_token ? static::generate_token() : $saved_token;
 		if ( ! $saved_token && ! headers_sent() ) {
 			$secure = apply_filters( 'mwform_secure_cookie', is_ssl() );
-			setcookie( static::KEY, static::$token, [
-				'expires'  => 0,
-				'path'     => COOKIEPATH,
-				'domain'   => COOKIE_DOMAIN,
-				'secure'   => $secure,
-				'httponly' => true,
-				'samesite' => 'Lax',
-			] );
+			setcookie(
+				static::KEY,
+				static::$token,
+				array(
+					'expires'  => 0,
+					'path'     => COOKIEPATH,
+					'domain'   => COOKIE_DOMAIN,
+					'secure'   => $secure,
+					'httponly' => true,
+					'samesite' => 'Lax',
+				)
+			);
 		}
 	}
 

--- a/classes/models/class.session.php
+++ b/classes/models/class.session.php
@@ -44,14 +44,18 @@ class MW_WP_Form_Session {
 			$secure     = apply_filters( 'mwform_secure_cookie', is_ssl() );
 			try {
 				set_error_handler( array( 'MW_WP_Form_Session', 'error_handler' ) );
-				setcookie( $this->name, $session_id, [
-					'expires' => 0,
-					'path' => COOKIEPATH,
-					'domain' => COOKIE_DOMAIN,
-					'secure' => $secure,
-					'httponly' => true,
-					'samesite' => 'Lax'
-				] );
+				setcookie(
+					$this->name,
+					$session_id,
+					array(
+						'expires'  => 0,
+						'path'     => COOKIEPATH,
+						'domain'   => COOKIE_DOMAIN,
+						'secure'   => $secure,
+						'httponly' => true,
+						'samesite' => 'Lax',
+					)
+				);
 			} catch ( ErrorException $e ) {
 				// No process...
 			}


### PR DESCRIPTION
## Summary
PR #35, #36 でマージされた `setcookie()` の配列引数形式が phpcs (WordPress Coding Standards) ルールに違反し、develop ブランチの CI が失敗していたため修正。

- short array 記法 (`[...]`) を `array(...)` に変更
- 複数行関数呼び出しの括弧・引数配置の整形
- 配列キーのアライメント (`=>` の空白)

## Test plan
- [ ] CI (Test Plugin) がパスする