### PR TITLE
feat: 5.2 で削除予定の機能を使うフォームに管理画面で警告を表示

### DIFF
--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -11,6 +11,11 @@
 class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 
 	/**
+	 * Cache key for the list of forms using shortcodes scheduled for removal.
+	 */
+	const DEPRECATED_SHORTCODES_CACHE_KEY = 'mwform_deprecated_shortcodes_forms';
+
+	/**
 	 * @var array
 	 */
 	protected $styles = array();
@@ -25,6 +30,10 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 		add_action( 'admin_enqueue_scripts', array( $this, '_admin_enqueue_scripts' ) );
 		add_action( 'save_post', array( $this, '_save_post' ) );
 		add_action( 'admin_notices', array( $this, '_deprecated_feature_notice' ) );
+		add_action( 'save_post_' . MWF_Config::NAME, array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
+		add_action( 'deleted_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
+		add_action( 'trashed_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
+		add_action( 'untrashed_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
 	}
 
 	/**
@@ -110,11 +119,12 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 
 	/**
 	 * Display an admin notice listing all forms that use shortcodes
-	 * scheduled for removal in a future release.
+	 * scheduled for removal in a future release. Shown on every admin page
+	 * so that the notice is surfaced even when administrators do not open
+	 * the MW WP Form settings.
 	 */
 	public function _deprecated_feature_notice() {
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		if ( empty( $screen ) || MWF_Config::NAME !== $screen->post_type ) {
+		if ( ! current_user_can( MWF_Config::CAPABILITY ) ) {
 			return;
 		}
 
@@ -169,12 +179,17 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 	 * @return array<object{ID:int,post_title:string}>
 	 */
 	protected function _get_forms_using_deprecated_shortcodes() {
+		$cached = get_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
 		global $wpdb;
 
 		$like_file  = '%' . $wpdb->esc_like( '[mwform_file' ) . '%';
 		$like_image = '%' . $wpdb->esc_like( '[mwform_image' ) . '%';
 
-		return $wpdb->get_results(
+		$results = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT ID, post_title FROM {$wpdb->posts}
 				 WHERE post_type = %s
@@ -186,6 +201,26 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 				$like_image
 			)
 		);
+
+		if ( ! is_array( $results ) ) {
+			$results = array();
+		}
+
+		set_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY, $results, HOUR_IN_SECONDS );
+		return $results;
+	}
+
+	/**
+	 * Invalidate the cached list of forms using deprecated shortcodes.
+	 * Fires when a form is saved, deleted, trashed, or untrashed.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function _invalidate_deprecated_shortcodes_cache( $post_id = 0 ) {
+		if ( $post_id && MWF_Config::NAME !== get_post_type( $post_id ) ) {
+			return;
+		}
+		delete_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY );
 	}
 
 	/**

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -109,30 +109,81 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 	}
 
 	/**
-	 * Display an admin notice when the edited form uses shortcodes that
-	 * will be removed in a future release.
+	 * Display an admin notice listing all forms that use shortcodes
+	 * scheduled for removal in a future release.
 	 */
 	public function _deprecated_feature_notice() {
-		global $post;
-
-		if ( empty( $post ) || MWF_Config::NAME !== get_post_type( $post ) ) {
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( empty( $screen ) || MWF_Config::NAME !== $screen->post_type ) {
 			return;
 		}
 
-		if ( ! preg_match( '/\[(mwform_file|mwform_image)(\s|\])/', (string) $post->post_content ) ) {
+		$affected_forms = $this->_get_forms_using_deprecated_shortcodes();
+		if ( empty( $affected_forms ) ) {
 			return;
 		}
 
-		printf(
-			'<div class="notice notice-warning"><p><strong>%1$s</strong><br>%2$s</p></div>',
-			esc_html__( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ),
-			esc_html(
-				sprintf(
+		$list_items = array();
+		foreach ( $affected_forms as $form ) {
+			$edit_link = get_edit_post_link( $form->ID );
+			$title     = '' !== (string) $form->post_title
+				? $form->post_title
+				: __( '(no title)', 'mw-wp-form' );
+
+			if ( $edit_link ) {
+				$list_items[] = sprintf(
+					'<a href="%1$s">%2$s</a>',
+					esc_url( $edit_link ),
+					esc_html( $title )
+				);
+			} else {
+				$list_items[] = esc_html( $title );
+			}
+		}
+
+		?>
+		<div class="notice notice-warning">
+			<p>
+				<strong><?php esc_html_e( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ); ?></strong><br>
+				<?php
+				printf(
 					/* translators: 1: Version number, 2: Planned year of removal. */
-					__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s). This form currently uses one of these shortcodes.', 'mw-wp-form' ),
+					esc_html__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s).', 'mw-wp-form' ),
 					'5.2',
 					'2026'
-				)
+				);
+				?>
+			</p>
+			<p>
+				<?php esc_html_e( 'The following form(s) currently use these shortcodes:', 'mw-wp-form' ); ?>
+				<?php echo implode( ', ', $list_items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Individual items escaped above. ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Return mw-wp-form posts whose content contains shortcodes scheduled
+	 * for removal.
+	 *
+	 * @return array<object{ID:int,post_title:string}>
+	 */
+	protected function _get_forms_using_deprecated_shortcodes() {
+		global $wpdb;
+
+		$like_file  = '%' . $wpdb->esc_like( '[mwform_file' ) . '%';
+		$like_image = '%' . $wpdb->esc_like( '[mwform_image' ) . '%';
+
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_title FROM {$wpdb->posts}
+				 WHERE post_type = %s
+				   AND post_status NOT IN ( 'trash', 'auto-draft' )
+				   AND ( post_content LIKE %s OR post_content LIKE %s )
+				 ORDER BY post_title ASC",
+				MWF_Config::NAME,
+				$like_file,
+				$like_image
 			)
 		);
 	}

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -24,6 +24,7 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 		add_action( 'media_buttons', array( $this, '_tag_generator' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, '_admin_enqueue_scripts' ) );
 		add_action( 'save_post', array( $this, '_save_post' ) );
+		add_action( 'admin_notices', array( $this, '_deprecated_feature_notice' ) );
 	}
 
 	/**
@@ -105,6 +106,35 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 				'side'
 			);
 		}
+	}
+
+	/**
+	 * Display an admin notice when the edited form uses shortcodes that
+	 * will be removed in a future release.
+	 */
+	public function _deprecated_feature_notice() {
+		global $post;
+
+		if ( empty( $post ) || MWF_Config::NAME !== get_post_type( $post ) ) {
+			return;
+		}
+
+		if ( ! preg_match( '/\[(mwform_file|mwform_image)(\s|\])/', (string) $post->post_content ) ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-warning"><p><strong>%1$s</strong><br>%2$s</p></div>',
+			esc_html__( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ),
+			esc_html(
+				sprintf(
+					/* translators: 1: Version number, 2: Planned year of removal. */
+					__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s). This form currently uses one of these shortcodes.', 'mw-wp-form' ),
+					'5.2',
+					'2026'
+				)
+			)
+		);
 	}
 
 	/**

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -11,11 +11,6 @@
 class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 
 	/**
-	 * Cache key for the list of forms using shortcodes scheduled for removal.
-	 */
-	const DEPRECATED_SHORTCODES_CACHE_KEY = 'mwform_deprecated_shortcodes_forms';
-
-	/**
 	 * @var array
 	 */
 	protected $styles = array();
@@ -29,11 +24,6 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 		add_action( 'media_buttons', array( $this, '_tag_generator' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, '_admin_enqueue_scripts' ) );
 		add_action( 'save_post', array( $this, '_save_post' ) );
-		add_action( 'admin_notices', array( $this, '_deprecated_feature_notice' ) );
-		add_action( 'save_post_' . MWF_Config::NAME, array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
-		add_action( 'deleted_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
-		add_action( 'trashed_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
-		add_action( 'untrashed_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
 	}
 
 	/**
@@ -115,112 +105,6 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 				'side'
 			);
 		}
-	}
-
-	/**
-	 * Display an admin notice listing all forms that use shortcodes
-	 * scheduled for removal in a future release. Shown on every admin page
-	 * so that the notice is surfaced even when administrators do not open
-	 * the MW WP Form settings.
-	 */
-	public function _deprecated_feature_notice() {
-		if ( ! current_user_can( MWF_Config::CAPABILITY ) ) {
-			return;
-		}
-
-		$affected_forms = $this->_get_forms_using_deprecated_shortcodes();
-		if ( empty( $affected_forms ) ) {
-			return;
-		}
-
-		$list_items = array();
-		foreach ( $affected_forms as $form ) {
-			$edit_link = get_edit_post_link( $form->ID );
-			$title     = '' !== (string) $form->post_title
-				? $form->post_title
-				: __( '(no title)', 'mw-wp-form' );
-
-			if ( $edit_link ) {
-				$list_items[] = sprintf(
-					'<a href="%1$s">%2$s</a>',
-					esc_url( $edit_link ),
-					esc_html( $title )
-				);
-			} else {
-				$list_items[] = esc_html( $title );
-			}
-		}
-
-		?>
-		<div class="notice notice-warning">
-			<p>
-				<strong><?php esc_html_e( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ); ?></strong><br>
-				<?php
-				printf(
-					/* translators: 1: Version number, 2: Planned year of removal. */
-					esc_html__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s).', 'mw-wp-form' ),
-					'5.2',
-					'2026'
-				);
-				?>
-			</p>
-			<p>
-				<?php esc_html_e( 'The following form(s) currently use these shortcodes:', 'mw-wp-form' ); ?>
-				<?php echo implode( ', ', $list_items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Individual items escaped above. ?>
-			</p>
-		</div>
-		<?php
-	}
-
-	/**
-	 * Return mw-wp-form posts whose content contains shortcodes scheduled
-	 * for removal.
-	 *
-	 * @return array<object{ID:int,post_title:string}>
-	 */
-	protected function _get_forms_using_deprecated_shortcodes() {
-		$cached = get_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY );
-		if ( false !== $cached ) {
-			return $cached;
-		}
-
-		global $wpdb;
-
-		$like_file  = '%' . $wpdb->esc_like( '[mwform_file' ) . '%';
-		$like_image = '%' . $wpdb->esc_like( '[mwform_image' ) . '%';
-
-		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT ID, post_title FROM {$wpdb->posts}
-				 WHERE post_type = %s
-				   AND post_status NOT IN ( 'trash', 'auto-draft' )
-				   AND ( post_content LIKE %s OR post_content LIKE %s )
-				 ORDER BY post_title ASC",
-				MWF_Config::NAME,
-				$like_file,
-				$like_image
-			)
-		);
-
-		if ( ! is_array( $results ) ) {
-			$results = array();
-		}
-
-		set_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY, $results, HOUR_IN_SECONDS );
-		return $results;
-	}
-
-	/**
-	 * Invalidate the cached list of forms using deprecated shortcodes.
-	 * Fires when a form is saved, deleted, trashed, or untrashed.
-	 *
-	 * @param int $post_id Post ID.
-	 */
-	public function _invalidate_deprecated_shortcodes_cache( $post_id = 0 ) {
-		if ( $post_id && MWF_Config::NAME !== get_post_type( $post_id ) ) {
-			return;
-		}
-		delete_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY );
 	}
 
 	/**

--- a/classes/controllers/class.deprecation-notice.php
+++ b/classes/controllers/class.deprecation-notice.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * @package mw-wp-form
+ * @author websoudan
+ * @license GPL-2.0+
+ */
+
+/**
+ * MW_WP_Form_Deprecation_Notice_Controller
+ *
+ * Displays a deprecation notice across every admin page when forms that use
+ * shortcodes scheduled for removal exist. Split out from the form edit
+ * controller so that the notice appears even when administrators are not
+ * currently editing a form.
+ */
+class MW_WP_Form_Deprecation_Notice_Controller {
+
+	/**
+	 * Cache key for the list of forms using shortcodes scheduled for removal.
+	 */
+	const CACHE_KEY = 'mwform_deprecated_shortcodes_forms';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_notices', array( $this, '_notice' ) );
+		add_action( 'save_post_' . MWF_Config::NAME, array( $this, '_invalidate_cache' ) );
+		add_action( 'deleted_post', array( $this, '_invalidate_cache' ) );
+		add_action( 'trashed_post', array( $this, '_invalidate_cache' ) );
+		add_action( 'untrashed_post', array( $this, '_invalidate_cache' ) );
+	}
+
+	/**
+	 * Display an admin notice listing all forms that use shortcodes
+	 * scheduled for removal in a future release.
+	 */
+	public function _notice() {
+		if ( ! current_user_can( MWF_Config::CAPABILITY ) ) {
+			return;
+		}
+
+		$affected_forms = $this->_get_forms_using_deprecated_shortcodes();
+		if ( empty( $affected_forms ) ) {
+			return;
+		}
+
+		$list_items = array();
+		foreach ( $affected_forms as $form ) {
+			$edit_link = get_edit_post_link( $form->ID );
+			$title     = '' !== (string) $form->post_title
+				? $form->post_title
+				: __( '(no title)', 'mw-wp-form' );
+
+			if ( $edit_link ) {
+				$list_items[] = sprintf(
+					'<a href="%1$s">%2$s</a>',
+					esc_url( $edit_link ),
+					esc_html( $title )
+				);
+			} else {
+				$list_items[] = esc_html( $title );
+			}
+		}
+
+		?>
+		<div class="notice notice-warning">
+			<p>
+				<strong><?php esc_html_e( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ); ?></strong><br>
+				<?php
+				printf(
+					/* translators: 1: Version number, 2: Planned year of removal. */
+					esc_html__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s).', 'mw-wp-form' ),
+					'5.2',
+					'2026'
+				);
+				?>
+			</p>
+			<p>
+				<?php esc_html_e( 'The following form(s) currently use these shortcodes:', 'mw-wp-form' ); ?>
+				<?php echo implode( ', ', $list_items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Individual items escaped above. ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Return mw-wp-form posts whose content contains shortcodes scheduled
+	 * for removal.
+	 *
+	 * @return array<object{ID:int,post_title:string}>
+	 */
+	protected function _get_forms_using_deprecated_shortcodes() {
+		$cached = get_transient( self::CACHE_KEY );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		global $wpdb;
+
+		$like_file  = '%' . $wpdb->esc_like( '[mwform_file' ) . '%';
+		$like_image = '%' . $wpdb->esc_like( '[mwform_image' ) . '%';
+
+		$candidates = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_title, post_content FROM {$wpdb->posts}
+				 WHERE post_type = %s
+				   AND post_status NOT IN ( 'trash', 'auto-draft' )
+				   AND ( post_content LIKE %s OR post_content LIKE %s )
+				 ORDER BY post_title ASC",
+				MWF_Config::NAME,
+				$like_file,
+				$like_image
+			)
+		);
+
+		$results = array();
+		if ( is_array( $candidates ) ) {
+			foreach ( $candidates as $row ) {
+				// LIKE can match other shortcodes whose name begins with
+				// "mwform_file" or "mwform_image" (e.g. "mwform_filepicker").
+				// Re-check with a shortcode-aware regex.
+				if ( preg_match( '/\[(mwform_file|mwform_image)(\s|\])/', (string) $row->post_content ) ) {
+					$results[] = (object) array(
+						'ID'         => (int) $row->ID,
+						'post_title' => (string) $row->post_title,
+					);
+				}
+			}
+		}
+
+		set_transient( self::CACHE_KEY, $results, HOUR_IN_SECONDS );
+		return $results;
+	}
+
+	/**
+	 * Invalidate the cached list of forms using deprecated shortcodes.
+	 * Fires when a form is saved, deleted, trashed, or untrashed.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function _invalidate_cache( $post_id = 0 ) {
+		if ( $post_id && MWF_Config::NAME !== get_post_type( $post_id ) ) {
+			return;
+		}
+		delete_transient( self::CACHE_KEY );
+	}
+}

--- a/mw-wp-form.php
+++ b/mw-wp-form.php
@@ -80,6 +80,7 @@ class MW_WP_Form {
 			add_action( 'admin_menu', array( $this, '_admin_menu_for_chart' ) );
 			add_action( 'admin_menu', array( $this, '_admin_menu_for_inquiry_data_list' ) );
 			add_action( 'current_screen', array( $this, '_current_screen' ) );
+			new MW_WP_Form_Deprecation_Notice_Controller();
 		} elseif ( ! is_admin() ) {
 			new MW_WP_Form_Main_Controller();
 		}

--- a/tests/classes/controllers/test-deprecation-notice.php
+++ b/tests/classes/controllers/test-deprecation-notice.php
@@ -1,0 +1,220 @@
+<?php
+class MW_WP_Form_Deprecation_Notice_Controller_Test extends WP_UnitTestCase {
+
+	public function tear_down() {
+		delete_transient( MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY );
+		parent::tear_down();
+		_delete_all_data();
+	}
+
+	/**
+	 * Create a mw-wp-form post.
+	 *
+	 * @param string $content Post content.
+	 * @param string $status  Post status.
+	 * @return int Post ID.
+	 */
+	protected function _create_form( $content = '', $status = 'publish' ) {
+		return $this->factory->post->create(
+			array(
+				'post_type'    => MWF_Config::NAME,
+				'post_status'  => $status,
+				'post_content' => $content,
+			)
+		);
+	}
+
+	/**
+	 * Set an administrator as the current user so that capability checks pass.
+	 */
+	protected function _login_as_admin() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Capture the output of _notice().
+	 *
+	 * @return string
+	 */
+	protected function _capture_notice() {
+		$controller = new MW_WP_Form_Deprecation_Notice_Controller();
+		ob_start();
+		$controller->_notice();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_empty_when_no_forms_exist() {
+		$this->_login_as_admin();
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_empty_when_forms_do_not_use_target_shortcodes() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_text name="a"][mwform_email name="b"]' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_rendered_when_form_uses_mwform_file() {
+		$this->_login_as_admin();
+		$form_id = $this->_create_form( '[mwform_file name="attachment"]' );
+		get_post( $form_id )->post_title = 'File form';
+		wp_update_post(
+			array(
+				'ID'         => $form_id,
+				'post_title' => 'File form',
+			)
+		);
+
+		$output = $this->_capture_notice();
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( 'File form', $output );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_rendered_when_form_uses_mwform_image() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_image name="pic"]' );
+
+		$this->assertStringContainsString( 'notice-warning', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_empty_for_unauthorized_user() {
+		// No login — unauthenticated visitor.
+		$this->_create_form( '[mwform_file name="a"]' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_excludes_trashed_forms() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_file name="a"]', 'trash' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_excludes_auto_draft_forms() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_file name="a"]', 'auto-draft' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_excludes_non_mw_wp_form_posts() {
+		$this->_login_as_admin();
+		$this->factory->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_content' => '[mwform_file name="a"]',
+			)
+		);
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_does_not_match_partial_shortcode_names() {
+		$this->_login_as_admin();
+		// Contains `mwform_filepicker` which must not be mistaken for
+		// `mwform_file` through LIKE wildcard collapsing.
+		$this->_create_form( '[mwform_filepicker name="a"]' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function cache_is_populated_after_query() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_file name="a"]' );
+
+		$this->_capture_notice();
+
+		$cached = get_transient( MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY );
+		$this->assertIsArray( $cached );
+		$this->assertCount( 1, $cached );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function cache_is_invalidated_for_mw_wp_form_post() {
+		$this->_login_as_admin();
+		$form_id = $this->_create_form( '[mwform_file name="a"]' );
+
+		$controller = new MW_WP_Form_Deprecation_Notice_Controller();
+		set_transient(
+			MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY,
+			array( (object) array( 'ID' => $form_id, 'post_title' => 'stale' ) ),
+			HOUR_IN_SECONDS
+		);
+
+		$controller->_invalidate_cache( $form_id );
+
+		$this->assertFalse( get_transient( MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY ) );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function cache_is_not_invalidated_for_non_mw_wp_form_post() {
+		$this->_login_as_admin();
+		$other_post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		$controller = new MW_WP_Form_Deprecation_Notice_Controller();
+		set_transient(
+			MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY,
+			array(),
+			HOUR_IN_SECONDS
+		);
+
+		$controller->_invalidate_cache( $other_post_id );
+
+		$this->assertIsArray( get_transient( MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY ) );
+	}
+}


### PR DESCRIPTION
## Summary
2026 年内にリリース予定の 5.2 で一部機能を削除することに伴い、該当機能を利用しているフォームがある場合、**全管理画面で** 事前警告を表示する。

運用中のサイトでは MW WP Form の設定画面を開くことがほぼ無いため、警告が気付かれない可能性がある。このため、MW WP Form の管理画面に限らず全ての管理画面で表示するようにした。

- `admin_notices` で全管理画面に `notice notice-warning` を出力
- 表示対象は `MWF_Config::CAPABILITY` (edit_pages) を持つユーザーのみ
- 全 `mw-wp-form` 投稿 (trash / auto-draft を除く) を検索し、`post_content` に `[mwform_file]` または `[mwform_image]` を含むフォームを抽出
- ヒットしたフォームを編集リンク付きで列挙
- 全ページでの DB アクセスを避けるため、検索結果を 1 時間 transient キャッシュ
- フォーム保存・削除・ゴミ箱移動・復元時にキャッシュを無効化
- 既存フォームの挙動は変更しない

Closes #41

## Test plan
- [ ] `[mwform_file]` を含むフォームがあると、ダッシュボード等すべての管理画面で警告が表示される
- [ ] `[mwform_image]` を含むフォームがあると、同様に警告が表示される
- [ ] 対象ショートコードを含むフォームがない場合は警告が表示されない
- [ ] `edit_pages` 権限を持たないユーザーには表示されない
- [ ] trash / auto-draft のフォームは検出対象外
- [ ] フォームを編集してショートコードを追加/削除すると、次のページロードで警告の表示状態が更新される
- [ ] CI がパスする