### PR TITLE
Release 5.1.3

### DIFF
--- a/classes/abstract/class.form-field.php
+++ b/classes/abstract/class.form-field.php
@@ -129,7 +129,7 @@ abstract class MW_WP_Form_Abstract_Form_Field {
 		$args = $this->set_names();
 
 		if ( empty( $args['shortcode_name'] ) || empty( $args['display_name'] ) ) {
-			exit( get_class() . '::set_names() returns not right values. Returned values is ' . serialize( $args ) . ' now.' );
+			exit( get_class( $this ) . '::set_names() returns not right values. Returned values is ' . serialize( $args ) . ' now.' );
 		}
 
 		$this->shortcode_name = $args['shortcode_name'];

--- a/classes/abstract/class.validation-rule.php
+++ b/classes/abstract/class.validation-rule.php
@@ -88,8 +88,8 @@ abstract class MW_WP_Form_Abstract_Validation_Rule {
 	 */
 	public function getName() {
 		MWF_Functions::deprecated_message(
-			get_class() . '::getName()',
-			get_class() . '::get_name()'
+			get_class( $this ) . '::getName()',
+			get_class( $this ) . '::get_name()'
 		);
 		return $this->get_name();
 	}

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -11,6 +11,11 @@
 class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 
 	/**
+	 * Cache key for the list of forms using shortcodes scheduled for removal.
+	 */
+	const DEPRECATED_SHORTCODES_CACHE_KEY = 'mwform_deprecated_shortcodes_forms';
+
+	/**
 	 * @var array
 	 */
 	protected $styles = array();
@@ -25,6 +30,10 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 		add_action( 'admin_enqueue_scripts', array( $this, '_admin_enqueue_scripts' ) );
 		add_action( 'save_post', array( $this, '_save_post' ) );
 		add_action( 'admin_notices', array( $this, '_deprecated_feature_notice' ) );
+		add_action( 'save_post_' . MWF_Config::NAME, array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
+		add_action( 'deleted_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
+		add_action( 'trashed_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
+		add_action( 'untrashed_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
 	}
 
 	/**
@@ -110,11 +119,12 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 
 	/**
 	 * Display an admin notice listing all forms that use shortcodes
-	 * scheduled for removal in a future release.
+	 * scheduled for removal in a future release. Shown on every admin page
+	 * so that the notice is surfaced even when administrators do not open
+	 * the MW WP Form settings.
 	 */
 	public function _deprecated_feature_notice() {
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		if ( empty( $screen ) || MWF_Config::NAME !== $screen->post_type ) {
+		if ( ! current_user_can( MWF_Config::CAPABILITY ) ) {
 			return;
 		}
 
@@ -169,12 +179,17 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 	 * @return array<object{ID:int,post_title:string}>
 	 */
 	protected function _get_forms_using_deprecated_shortcodes() {
+		$cached = get_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
 		global $wpdb;
 
 		$like_file  = '%' . $wpdb->esc_like( '[mwform_file' ) . '%';
 		$like_image = '%' . $wpdb->esc_like( '[mwform_image' ) . '%';
 
-		return $wpdb->get_results(
+		$results = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT ID, post_title FROM {$wpdb->posts}
 				 WHERE post_type = %s
@@ -186,6 +201,26 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 				$like_image
 			)
 		);
+
+		if ( ! is_array( $results ) ) {
+			$results = array();
+		}
+
+		set_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY, $results, HOUR_IN_SECONDS );
+		return $results;
+	}
+
+	/**
+	 * Invalidate the cached list of forms using deprecated shortcodes.
+	 * Fires when a form is saved, deleted, trashed, or untrashed.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function _invalidate_deprecated_shortcodes_cache( $post_id = 0 ) {
+		if ( $post_id && MWF_Config::NAME !== get_post_type( $post_id ) ) {
+			return;
+		}
+		delete_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY );
 	}
 
 	/**

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -109,30 +109,81 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 	}
 
 	/**
-	 * Display an admin notice when the edited form uses shortcodes that
-	 * will be removed in a future release.
+	 * Display an admin notice listing all forms that use shortcodes
+	 * scheduled for removal in a future release.
 	 */
 	public function _deprecated_feature_notice() {
-		global $post;
-
-		if ( empty( $post ) || MWF_Config::NAME !== get_post_type( $post ) ) {
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( empty( $screen ) || MWF_Config::NAME !== $screen->post_type ) {
 			return;
 		}
 
-		if ( ! preg_match( '/\[(mwform_file|mwform_image)(\s|\])/', (string) $post->post_content ) ) {
+		$affected_forms = $this->_get_forms_using_deprecated_shortcodes();
+		if ( empty( $affected_forms ) ) {
 			return;
 		}
 
-		printf(
-			'<div class="notice notice-warning"><p><strong>%1$s</strong><br>%2$s</p></div>',
-			esc_html__( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ),
-			esc_html(
-				sprintf(
+		$list_items = array();
+		foreach ( $affected_forms as $form ) {
+			$edit_link = get_edit_post_link( $form->ID );
+			$title     = '' !== (string) $form->post_title
+				? $form->post_title
+				: __( '(no title)', 'mw-wp-form' );
+
+			if ( $edit_link ) {
+				$list_items[] = sprintf(
+					'<a href="%1$s">%2$s</a>',
+					esc_url( $edit_link ),
+					esc_html( $title )
+				);
+			} else {
+				$list_items[] = esc_html( $title );
+			}
+		}
+
+		?>
+		<div class="notice notice-warning">
+			<p>
+				<strong><?php esc_html_e( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ); ?></strong><br>
+				<?php
+				printf(
 					/* translators: 1: Version number, 2: Planned year of removal. */
-					__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s). This form currently uses one of these shortcodes.', 'mw-wp-form' ),
+					esc_html__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s).', 'mw-wp-form' ),
 					'5.2',
 					'2026'
-				)
+				);
+				?>
+			</p>
+			<p>
+				<?php esc_html_e( 'The following form(s) currently use these shortcodes:', 'mw-wp-form' ); ?>
+				<?php echo implode( ', ', $list_items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Individual items escaped above. ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Return mw-wp-form posts whose content contains shortcodes scheduled
+	 * for removal.
+	 *
+	 * @return array<object{ID:int,post_title:string}>
+	 */
+	protected function _get_forms_using_deprecated_shortcodes() {
+		global $wpdb;
+
+		$like_file  = '%' . $wpdb->esc_like( '[mwform_file' ) . '%';
+		$like_image = '%' . $wpdb->esc_like( '[mwform_image' ) . '%';
+
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_title FROM {$wpdb->posts}
+				 WHERE post_type = %s
+				   AND post_status NOT IN ( 'trash', 'auto-draft' )
+				   AND ( post_content LIKE %s OR post_content LIKE %s )
+				 ORDER BY post_title ASC",
+				MWF_Config::NAME,
+				$like_file,
+				$like_image
 			)
 		);
 	}

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -24,6 +24,7 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 		add_action( 'media_buttons', array( $this, '_tag_generator' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, '_admin_enqueue_scripts' ) );
 		add_action( 'save_post', array( $this, '_save_post' ) );
+		add_action( 'admin_notices', array( $this, '_deprecated_feature_notice' ) );
 	}
 
 	/**
@@ -105,6 +106,35 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 				'side'
 			);
 		}
+	}
+
+	/**
+	 * Display an admin notice when the edited form uses shortcodes that
+	 * will be removed in a future release.
+	 */
+	public function _deprecated_feature_notice() {
+		global $post;
+
+		if ( empty( $post ) || MWF_Config::NAME !== get_post_type( $post ) ) {
+			return;
+		}
+
+		if ( ! preg_match( '/\[(mwform_file|mwform_image)(\s|\])/', (string) $post->post_content ) ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-warning"><p><strong>%1$s</strong><br>%2$s</p></div>',
+			esc_html__( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ),
+			esc_html(
+				sprintf(
+					/* translators: 1: Version number, 2: Planned year of removal. */
+					__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s). This form currently uses one of these shortcodes.', 'mw-wp-form' ),
+					'5.2',
+					'2026'
+				)
+			)
+		);
 	}
 
 	/**

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -11,11 +11,6 @@
 class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 
 	/**
-	 * Cache key for the list of forms using shortcodes scheduled for removal.
-	 */
-	const DEPRECATED_SHORTCODES_CACHE_KEY = 'mwform_deprecated_shortcodes_forms';
-
-	/**
 	 * @var array
 	 */
 	protected $styles = array();
@@ -29,11 +24,6 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 		add_action( 'media_buttons', array( $this, '_tag_generator' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, '_admin_enqueue_scripts' ) );
 		add_action( 'save_post', array( $this, '_save_post' ) );
-		add_action( 'admin_notices', array( $this, '_deprecated_feature_notice' ) );
-		add_action( 'save_post_' . MWF_Config::NAME, array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
-		add_action( 'deleted_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
-		add_action( 'trashed_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
-		add_action( 'untrashed_post', array( $this, '_invalidate_deprecated_shortcodes_cache' ) );
 	}
 
 	/**
@@ -115,112 +105,6 @@ class MW_WP_Form_Admin_Controller extends MW_WP_Form_Controller {
 				'side'
 			);
 		}
-	}
-
-	/**
-	 * Display an admin notice listing all forms that use shortcodes
-	 * scheduled for removal in a future release. Shown on every admin page
-	 * so that the notice is surfaced even when administrators do not open
-	 * the MW WP Form settings.
-	 */
-	public function _deprecated_feature_notice() {
-		if ( ! current_user_can( MWF_Config::CAPABILITY ) ) {
-			return;
-		}
-
-		$affected_forms = $this->_get_forms_using_deprecated_shortcodes();
-		if ( empty( $affected_forms ) ) {
-			return;
-		}
-
-		$list_items = array();
-		foreach ( $affected_forms as $form ) {
-			$edit_link = get_edit_post_link( $form->ID );
-			$title     = '' !== (string) $form->post_title
-				? $form->post_title
-				: __( '(no title)', 'mw-wp-form' );
-
-			if ( $edit_link ) {
-				$list_items[] = sprintf(
-					'<a href="%1$s">%2$s</a>',
-					esc_url( $edit_link ),
-					esc_html( $title )
-				);
-			} else {
-				$list_items[] = esc_html( $title );
-			}
-		}
-
-		?>
-		<div class="notice notice-warning">
-			<p>
-				<strong><?php esc_html_e( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ); ?></strong><br>
-				<?php
-				printf(
-					/* translators: 1: Version number, 2: Planned year of removal. */
-					esc_html__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s).', 'mw-wp-form' ),
-					'5.2',
-					'2026'
-				);
-				?>
-			</p>
-			<p>
-				<?php esc_html_e( 'The following form(s) currently use these shortcodes:', 'mw-wp-form' ); ?>
-				<?php echo implode( ', ', $list_items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Individual items escaped above. ?>
-			</p>
-		</div>
-		<?php
-	}
-
-	/**
-	 * Return mw-wp-form posts whose content contains shortcodes scheduled
-	 * for removal.
-	 *
-	 * @return array<object{ID:int,post_title:string}>
-	 */
-	protected function _get_forms_using_deprecated_shortcodes() {
-		$cached = get_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY );
-		if ( false !== $cached ) {
-			return $cached;
-		}
-
-		global $wpdb;
-
-		$like_file  = '%' . $wpdb->esc_like( '[mwform_file' ) . '%';
-		$like_image = '%' . $wpdb->esc_like( '[mwform_image' ) . '%';
-
-		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT ID, post_title FROM {$wpdb->posts}
-				 WHERE post_type = %s
-				   AND post_status NOT IN ( 'trash', 'auto-draft' )
-				   AND ( post_content LIKE %s OR post_content LIKE %s )
-				 ORDER BY post_title ASC",
-				MWF_Config::NAME,
-				$like_file,
-				$like_image
-			)
-		);
-
-		if ( ! is_array( $results ) ) {
-			$results = array();
-		}
-
-		set_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY, $results, HOUR_IN_SECONDS );
-		return $results;
-	}
-
-	/**
-	 * Invalidate the cached list of forms using deprecated shortcodes.
-	 * Fires when a form is saved, deleted, trashed, or untrashed.
-	 *
-	 * @param int $post_id Post ID.
-	 */
-	public function _invalidate_deprecated_shortcodes_cache( $post_id = 0 ) {
-		if ( $post_id && MWF_Config::NAME !== get_post_type( $post_id ) ) {
-			return;
-		}
-		delete_transient( self::DEPRECATED_SHORTCODES_CACHE_KEY );
 	}
 
 	/**

--- a/classes/controllers/class.deprecation-notice.php
+++ b/classes/controllers/class.deprecation-notice.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * @package mw-wp-form
+ * @author websoudan
+ * @license GPL-2.0+
+ */
+
+/**
+ * MW_WP_Form_Deprecation_Notice_Controller
+ *
+ * Displays a deprecation notice across every admin page when forms that use
+ * shortcodes scheduled for removal exist. Split out from the form edit
+ * controller so that the notice appears even when administrators are not
+ * currently editing a form.
+ */
+class MW_WP_Form_Deprecation_Notice_Controller {
+
+	/**
+	 * Cache key for the list of forms using shortcodes scheduled for removal.
+	 */
+	const CACHE_KEY = 'mwform_deprecated_shortcodes_forms';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_notices', array( $this, '_notice' ) );
+		add_action( 'save_post_' . MWF_Config::NAME, array( $this, '_invalidate_cache' ) );
+		add_action( 'deleted_post', array( $this, '_invalidate_cache' ) );
+		add_action( 'trashed_post', array( $this, '_invalidate_cache' ) );
+		add_action( 'untrashed_post', array( $this, '_invalidate_cache' ) );
+	}
+
+	/**
+	 * Display an admin notice listing all forms that use shortcodes
+	 * scheduled for removal in a future release.
+	 */
+	public function _notice() {
+		if ( ! current_user_can( MWF_Config::CAPABILITY ) ) {
+			return;
+		}
+
+		$affected_forms = $this->_get_forms_using_deprecated_shortcodes();
+		if ( empty( $affected_forms ) ) {
+			return;
+		}
+
+		$list_items = array();
+		foreach ( $affected_forms as $form ) {
+			$edit_link = get_edit_post_link( $form->ID );
+			$title     = '' !== (string) $form->post_title
+				? $form->post_title
+				: __( '(no title)', 'mw-wp-form' );
+
+			if ( $edit_link ) {
+				$list_items[] = sprintf(
+					'<a href="%1$s">%2$s</a>',
+					esc_url( $edit_link ),
+					esc_html( $title )
+				);
+			} else {
+				$list_items[] = esc_html( $title );
+			}
+		}
+
+		?>
+		<div class="notice notice-warning">
+			<p>
+				<strong><?php esc_html_e( 'MW WP Form: Notice of feature removal', 'mw-wp-form' ); ?></strong><br>
+				<?php
+				printf(
+					/* translators: 1: Version number, 2: Planned year of removal. */
+					esc_html__( 'The [mwform_file] and [mwform_image] shortcodes will be removed in version %1$s (planned for release within %2$s).', 'mw-wp-form' ),
+					'5.2',
+					'2026'
+				);
+				?>
+			</p>
+			<p>
+				<?php esc_html_e( 'The following form(s) currently use these shortcodes:', 'mw-wp-form' ); ?>
+				<?php echo implode( ', ', $list_items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Individual items escaped above. ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Return mw-wp-form posts whose content contains shortcodes scheduled
+	 * for removal.
+	 *
+	 * @return array<object{ID:int,post_title:string}>
+	 */
+	protected function _get_forms_using_deprecated_shortcodes() {
+		$cached = get_transient( self::CACHE_KEY );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		global $wpdb;
+
+		$like_file  = '%' . $wpdb->esc_like( '[mwform_file' ) . '%';
+		$like_image = '%' . $wpdb->esc_like( '[mwform_image' ) . '%';
+
+		$candidates = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_title, post_content FROM {$wpdb->posts}
+				 WHERE post_type = %s
+				   AND post_status NOT IN ( 'trash', 'auto-draft' )
+				   AND ( post_content LIKE %s OR post_content LIKE %s )
+				 ORDER BY post_title ASC",
+				MWF_Config::NAME,
+				$like_file,
+				$like_image
+			)
+		);
+
+		$results = array();
+		if ( is_array( $candidates ) ) {
+			foreach ( $candidates as $row ) {
+				// LIKE can match other shortcodes whose name begins with
+				// "mwform_file" or "mwform_image" (e.g. "mwform_filepicker").
+				// Re-check with a shortcode-aware regex.
+				if ( preg_match( '/\[(mwform_file|mwform_image)(\s|\])/', (string) $row->post_content ) ) {
+					$results[] = (object) array(
+						'ID'         => (int) $row->ID,
+						'post_title' => (string) $row->post_title,
+					);
+				}
+			}
+		}
+
+		set_transient( self::CACHE_KEY, $results, HOUR_IN_SECONDS );
+		return $results;
+	}
+
+	/**
+	 * Invalidate the cached list of forms using deprecated shortcodes.
+	 * Fires when a form is saved, deleted, trashed, or untrashed.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function _invalidate_cache( $post_id = 0 ) {
+		if ( $post_id && MWF_Config::NAME !== get_post_type( $post_id ) ) {
+			return;
+		}
+		delete_transient( self::CACHE_KEY );
+	}
+}

--- a/classes/models/class.csrf.php
+++ b/classes/models/class.csrf.php
@@ -40,14 +40,18 @@ class MW_WP_Form_Csrf {
 		static::$token = ! $saved_token ? static::generate_token() : $saved_token;
 		if ( ! $saved_token && ! headers_sent() ) {
 			$secure = apply_filters( 'mwform_secure_cookie', is_ssl() );
-			setcookie( static::KEY, static::$token, [
-				'expires'  => 0,
-				'path'     => COOKIEPATH,
-				'domain'   => COOKIE_DOMAIN,
-				'secure'   => $secure,
-				'httponly' => true,
-				'samesite' => 'Lax',
-			] );
+			setcookie(
+				static::KEY,
+				static::$token,
+				array(
+					'expires'  => 0,
+					'path'     => COOKIEPATH,
+					'domain'   => COOKIE_DOMAIN,
+					'secure'   => $secure,
+					'httponly' => true,
+					'samesite' => 'Lax',
+				)
+			);
 		}
 	}
 

--- a/classes/models/class.csrf.php
+++ b/classes/models/class.csrf.php
@@ -40,7 +40,14 @@ class MW_WP_Form_Csrf {
 		static::$token = ! $saved_token ? static::generate_token() : $saved_token;
 		if ( ! $saved_token && ! headers_sent() ) {
 			$secure = apply_filters( 'mwform_secure_cookie', is_ssl() );
-			setcookie( static::KEY, static::$token, 0, COOKIEPATH, COOKIE_DOMAIN, $secure, true );
+			setcookie( static::KEY, static::$token, [
+				'expires'  => 0,
+				'path'     => COOKIEPATH,
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => $secure,
+				'httponly' => true,
+				'samesite' => 'Lax',
+			] );
 		}
 	}
 

--- a/classes/models/class.parser.php
+++ b/classes/models/class.parser.php
@@ -134,6 +134,10 @@ class MW_WP_Form_Parser {
 			return;
 		}
 
+		if ( 'publish' !== $post->post_status || post_password_required( $post ) ) {
+			return;
+		}
+
 		return $this->_get_post_property( $post, $matches[1] );
 	}
 

--- a/classes/models/class.session.php
+++ b/classes/models/class.session.php
@@ -44,7 +44,14 @@ class MW_WP_Form_Session {
 			$secure     = apply_filters( 'mwform_secure_cookie', is_ssl() );
 			try {
 				set_error_handler( array( 'MW_WP_Form_Session', 'error_handler' ) );
-				setcookie( $this->name, $session_id, 0, COOKIEPATH, COOKIE_DOMAIN, $secure, true );
+				setcookie( $this->name, $session_id, [
+					'expires' => 0,
+					'path' => COOKIEPATH,
+					'domain' => COOKIE_DOMAIN,
+					'secure' => $secure,
+					'httponly' => true,
+					'samesite' => 'Lax'
+				] );
 			} catch ( ErrorException $e ) {
 				// No process...
 			}

--- a/classes/models/class.session.php
+++ b/classes/models/class.session.php
@@ -44,14 +44,18 @@ class MW_WP_Form_Session {
 			$secure     = apply_filters( 'mwform_secure_cookie', is_ssl() );
 			try {
 				set_error_handler( array( 'MW_WP_Form_Session', 'error_handler' ) );
-				setcookie( $this->name, $session_id, [
-					'expires' => 0,
-					'path' => COOKIEPATH,
-					'domain' => COOKIE_DOMAIN,
-					'secure' => $secure,
-					'httponly' => true,
-					'samesite' => 'Lax'
-				] );
+				setcookie(
+					$this->name,
+					$session_id,
+					array(
+						'expires'  => 0,
+						'path'     => COOKIEPATH,
+						'domain'   => COOKIE_DOMAIN,
+						'secure'   => $secure,
+						'httponly' => true,
+						'samesite' => 'Lax',
+					)
+				);
 			} catch ( ErrorException $e ) {
 				// No process...
 			}

--- a/classes/validation-rules/class.maximagesize.php
+++ b/classes/validation-rules/class.maximagesize.php
@@ -56,6 +56,7 @@ class MW_WP_Form_Validation_Rule_MaxImageSize extends MW_WP_Form_Abstract_Valida
 			$filepath = MW_WP_Form_Directory::generate_user_filepath( $form_id, $name, $value );
 		}
 
+		$imagesize = false;
 		if ( file_exists( $filepath ) && exif_imagetype( $filepath ) ) {
 			$imagesize = getimagesize( $filepath );
 		} else {
@@ -70,7 +71,7 @@ class MW_WP_Form_Validation_Rule_MaxImageSize extends MW_WP_Form_Abstract_Valida
 			'message' => __( 'This image size is too big.', 'mw-wp-form' ),
 		);
 		$options  = array_merge( $defaults, $options );
-		if ( $is_error || $imagesize[0] > $options['width'] || $imagesize[1] > $options['height'] ) {
+		if ( $is_error || ( is_array( $imagesize ) && ( $imagesize[0] > $options['width'] || $imagesize[1] > $options['height'] ) ) ) {
 			return $options['message'];
 		}
 	}

--- a/mw-wp-form.php
+++ b/mw-wp-form.php
@@ -3,7 +3,7 @@
  * Plugin Name: MW WP Form
  * Plugin URI: https://mw-wp-form.web-soudan.co.jp
  * Description: MW WP Form is shortcode base contact form plugin. This plugin have many features. For example you can use many validation rules, inquiry data saving, and chart aggregation using saved inquiry data.
- * Version: 5.1.2
+ * Version: 5.1.3
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Author: websoudan

--- a/mw-wp-form.php
+++ b/mw-wp-form.php
@@ -80,6 +80,7 @@ class MW_WP_Form {
 			add_action( 'admin_menu', array( $this, '_admin_menu_for_chart' ) );
 			add_action( 'admin_menu', array( $this, '_admin_menu_for_inquiry_data_list' ) );
 			add_action( 'current_screen', array( $this, '_current_screen' ) );
+			new MW_WP_Form_Deprecation_Notice_Controller();
 		} elseif ( ! is_admin() ) {
 			new MW_WP_Form_Main_Controller();
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: plugin, form, confirm, preview, shortcode, mail, chart, graph, html, conta
 Requires at least: 6.0
 Requires PHP: 8.0
 Tested up to: 6.4
-Stable tag: 5.1.2
+Stable tag: 5.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,13 @@ Do you have questions or issues with MW WP Form? Use these support channels appr
 5. Supports chart display of saved inquiry data.
 
 == Changelog ==
+
+= 5.1.3 =
+* Security Tighten access control on post property reference handling
+* Added Cookie SameSite=Lax attribute to CSRF / session cookies
+* Added Admin notice for [mwform_file] / [mwform_image] shortcodes, which are scheduled for removal in 5.2
+* Fixed PHP 8.3 Deprecated warning on get_class() without arguments
+* Fixed Undefined variable warning in maxfilesize (image size) validation rule
 
 = 5.1.2 =
 * Security Fix insufficient file path validation in upload file handling

--- a/tests/classes/controllers/test-deprecation-notice.php
+++ b/tests/classes/controllers/test-deprecation-notice.php
@@ -1,0 +1,220 @@
+<?php
+class MW_WP_Form_Deprecation_Notice_Controller_Test extends WP_UnitTestCase {
+
+	public function tear_down() {
+		delete_transient( MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY );
+		parent::tear_down();
+		_delete_all_data();
+	}
+
+	/**
+	 * Create a mw-wp-form post.
+	 *
+	 * @param string $content Post content.
+	 * @param string $status  Post status.
+	 * @return int Post ID.
+	 */
+	protected function _create_form( $content = '', $status = 'publish' ) {
+		return $this->factory->post->create(
+			array(
+				'post_type'    => MWF_Config::NAME,
+				'post_status'  => $status,
+				'post_content' => $content,
+			)
+		);
+	}
+
+	/**
+	 * Set an administrator as the current user so that capability checks pass.
+	 */
+	protected function _login_as_admin() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Capture the output of _notice().
+	 *
+	 * @return string
+	 */
+	protected function _capture_notice() {
+		$controller = new MW_WP_Form_Deprecation_Notice_Controller();
+		ob_start();
+		$controller->_notice();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_empty_when_no_forms_exist() {
+		$this->_login_as_admin();
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_empty_when_forms_do_not_use_target_shortcodes() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_text name="a"][mwform_email name="b"]' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_rendered_when_form_uses_mwform_file() {
+		$this->_login_as_admin();
+		$form_id = $this->_create_form( '[mwform_file name="attachment"]' );
+		get_post( $form_id )->post_title = 'File form';
+		wp_update_post(
+			array(
+				'ID'         => $form_id,
+				'post_title' => 'File form',
+			)
+		);
+
+		$output = $this->_capture_notice();
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( 'File form', $output );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_rendered_when_form_uses_mwform_image() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_image name="pic"]' );
+
+		$this->assertStringContainsString( 'notice-warning', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_is_empty_for_unauthorized_user() {
+		// No login — unauthenticated visitor.
+		$this->_create_form( '[mwform_file name="a"]' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_excludes_trashed_forms() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_file name="a"]', 'trash' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_excludes_auto_draft_forms() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_file name="a"]', 'auto-draft' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_excludes_non_mw_wp_form_posts() {
+		$this->_login_as_admin();
+		$this->factory->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_content' => '[mwform_file name="a"]',
+			)
+		);
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function notice_does_not_match_partial_shortcode_names() {
+		$this->_login_as_admin();
+		// Contains `mwform_filepicker` which must not be mistaken for
+		// `mwform_file` through LIKE wildcard collapsing.
+		$this->_create_form( '[mwform_filepicker name="a"]' );
+
+		$this->assertSame( '', $this->_capture_notice() );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function cache_is_populated_after_query() {
+		$this->_login_as_admin();
+		$this->_create_form( '[mwform_file name="a"]' );
+
+		$this->_capture_notice();
+
+		$cached = get_transient( MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY );
+		$this->assertIsArray( $cached );
+		$this->assertCount( 1, $cached );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function cache_is_invalidated_for_mw_wp_form_post() {
+		$this->_login_as_admin();
+		$form_id = $this->_create_form( '[mwform_file name="a"]' );
+
+		$controller = new MW_WP_Form_Deprecation_Notice_Controller();
+		set_transient(
+			MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY,
+			array( (object) array( 'ID' => $form_id, 'post_title' => 'stale' ) ),
+			HOUR_IN_SECONDS
+		);
+
+		$controller->_invalidate_cache( $form_id );
+
+		$this->assertFalse( get_transient( MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY ) );
+	}
+
+	/**
+	 * @test
+	 * @group deprecation_notice
+	 */
+	public function cache_is_not_invalidated_for_non_mw_wp_form_post() {
+		$this->_login_as_admin();
+		$other_post_id = $this->factory->post->create(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		$controller = new MW_WP_Form_Deprecation_Notice_Controller();
+		set_transient(
+			MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY,
+			array(),
+			HOUR_IN_SECONDS
+		);
+
+		$controller->_invalidate_cache( $other_post_id );
+
+		$this->assertIsArray( get_transient( MW_WP_Form_Deprecation_Notice_Controller::CACHE_KEY ) );
+	}
+}


### PR DESCRIPTION
## Summary

バージョン 5.1.3 のリリース PR。develop に蓄積された修正・機能追加・セキュリティ修正を master に反映する。

## Changelog

- **Security** — Tighten access control on post property reference handling (#40)
- **Added** — Cookie SameSite=Lax attribute to CSRF / session cookies (#35, #36)
- **Added** — Admin notice for `[mwform_file]` / `[mwform_image]` shortcodes scheduled for removal in 5.2 (#41, #42)
- **Fixed** — PHP 8.3 Deprecated warning on `get_class()` without arguments (#34, #37)
- **Fixed** — Undefined variable warning in maxfilesize (image size) validation rule (#33, #38)
- **Internal** — coding style fix for `setcookie()` array-form call (#39)

## Included PRs

- #35 Cookie SameSite 属性追加 (CSRF)
- #36 Cookie SameSite 属性追加 (Session)
- #37 fix: get_class() の引数なし呼び出しを修正 (PHP 8.3 Deprecated 対応)
- #38 fix: maximagesize で未初期化の $imagesize を参照する問題を修正
- #39 fix: setcookie 呼び出しのコーディングスタイル修正
- #40 security: 投稿情報参照処理のアクセス制御を強化
- #42 feat: 5.2 で削除予定の機能を使うフォームに管理画面で警告を表示

## Test plan

- [x] CI (Test Plugin) が develop / 各 PR でパス済み
- [x] PHPUnit ローカル実行: 183 件パス
- [x] phpcs ローカル実行: エラーなし
- [ ] master へのマージ後、タグ `5.1.3` を作成し wp.org に反映