### PR TITLE
security: メモ欄の出力エスケープを強化 (5.1.4)

### DIFF
--- a/mw-wp-form.php
+++ b/mw-wp-form.php
@@ -3,7 +3,7 @@
  * Plugin Name: MW WP Form
  * Plugin URI: https://mw-wp-form.web-soudan.co.jp
  * Description: MW WP Form is shortcode base contact form plugin. This plugin have many features. For example you can use many validation rules, inquiry data saving, and chart aggregation using saved inquiry data.
- * Version: 5.1.3
+ * Version: 5.1.4
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Author: websoudan

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: plugin, form, confirm, preview, shortcode, mail, chart, graph, html, conta
 Requires at least: 6.0
 Requires PHP: 8.0
 Tested up to: 6.4
-Stable tag: 5.1.3
+Stable tag: 5.1.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,9 @@ Do you have questions or issues with MW WP Form? Use these support channels appr
 5. Supports chart display of saved inquiry data.
 
 == Changelog ==
+
+= 5.1.4 =
+* Security Tighten output escaping on inquiry data detail screen
 
 = 5.1.3 =
 * Security Tighten access control on post property reference handling

--- a/templates/contact-data/detail.php
+++ b/templates/contact-data/detail.php
@@ -74,6 +74,6 @@
 	</tr>
 	<tr>
 		<th><?php esc_html_e( 'Memo', 'mw-wp-form' ); ?></th>
-		<td><textarea name="<?php echo esc_attr( MWF_Config::INQUIRY_DATA_NAME ); ?>[memo]" cols="50" rows="5"><?php echo $contact_data_setting->get( 'memo' ); ?></textarea></td>
+		<td><textarea name="<?php echo esc_attr( MWF_Config::INQUIRY_DATA_NAME ); ?>[memo]" cols="50" rows="5"><?php echo esc_textarea( $contact_data_setting->get( 'memo' ) ); ?></textarea></td>
 	</tr>
 </table>


### PR DESCRIPTION
## 概要

お問い合わせデータ詳細画面のメモ欄 (`templates/contact-data/detail.php`) で、`textarea` の出力に `esc_textarea()` が適用されていなかった問題を修正します。報告機関からの脆弱性指摘を受けた対応で、パッチは承認済みです。

## 変更内容

- `templates/contact-data/detail.php`: メモ値の出力に `esc_textarea()` を適用
- バージョンを 5.1.4 に bump、changelog を追記

## テスト

- [x] メモ欄に HTML 特殊文字を含む値を保存し、表示時に正しくエスケープされることを確認
- [x] 既存のメモ保存／読み込み動作に回帰がないことを確認

## リリース

マージ後、`5.1.4` タグを push し、`Deploy to WordPress.org` ワークフローで WordPress.org へ配布します。